### PR TITLE
Headers options 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add it in your root build.gradle at the **end** of repositories:
 Step 2. Add the dependency (based on latest release version)
 
 	dependencies {
-	        implementation 'com.github.adadaptedinc:android-sdk:3.0.2'
+	        implementation 'com.github.adadaptedinc:android-sdk:3.1.0'
 	}
 
 ## Running the tests

--- a/advertising_sdk/build.gradle
+++ b/advertising_sdk/build.gradle
@@ -21,7 +21,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 33
         versionCode 2
-        versionName "3.0.2"
+        versionName "3.1.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'aasdk-proguard-rules.pro'
     }

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/ext/http/HttpAdEventSink.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/ext/http/HttpAdEventSink.kt
@@ -4,6 +4,7 @@ import com.adadapted.android.sdk.config.EventStrings
 import com.adadapted.android.sdk.core.ad.AdEvent
 import com.adadapted.android.sdk.core.ad.AdEventSink
 import com.adadapted.android.sdk.core.session.Session
+import com.adadapted.android.sdk.ext.json.AdAdaptedJsonObjectRequest
 import com.adadapted.android.sdk.ext.json.JsonAdEventBuilder
 import com.android.volley.Request
 import com.android.volley.toolbox.JsonObjectRequest
@@ -15,7 +16,8 @@ class HttpAdEventSink(private val batchUrl: String, private val httpQueueManager
     override fun sendBatch(session: Session, events: Set<AdEvent>) {
         val json = builder.marshalEvents(session, events)
 
-        val jsonRequest = JsonObjectRequest(
+        val jsonRequest = AdAdaptedJsonObjectRequest(
+            httpQueueManager.getAppId(),
             Request.Method.POST,
             batchUrl,
             json,

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/ext/http/HttpAppEventSink.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/ext/http/HttpAppEventSink.kt
@@ -6,6 +6,7 @@ import com.adadapted.android.sdk.core.device.DeviceInfo
 import com.adadapted.android.sdk.core.event.AppError
 import com.adadapted.android.sdk.core.event.AppEvent
 import com.adadapted.android.sdk.core.event.AppEventSink
+import com.adadapted.android.sdk.ext.json.AdAdaptedJsonObjectRequest
 import com.adadapted.android.sdk.ext.json.JsonAppEventBuilder
 import com.android.volley.Request
 import com.android.volley.toolbox.JsonObjectRequest
@@ -16,6 +17,7 @@ class HttpAppEventSink(private val eventUrl: String, private val errorUrl: Strin
     private val eventBuilder: JsonAppEventBuilder = JsonAppEventBuilder()
     private var eventWrapper: JSONObject? = null
     private var errorWrapper: JSONObject? = null
+    private var appID: String = ""
 
     override fun generateWrappers(deviceInfo: DeviceInfo) {
         eventWrapper = eventBuilder.buildWrapper(deviceInfo)
@@ -28,7 +30,8 @@ class HttpAppEventSink(private val eventUrl: String, private val errorUrl: Strin
             return
         }
         val json = eventBuilder.buildEventItem(eventWrapper, events)
-        val jsonRequest = JsonObjectRequest(
+        val jsonRequest = AdAdaptedJsonObjectRequest(
+            httpQueueManager.getAppId(),
             Request.Method.POST,
             eventUrl,
             json,
@@ -50,7 +53,8 @@ class HttpAppEventSink(private val eventUrl: String, private val errorUrl: Strin
             return
         }
         val json = eventBuilder.buildErrorItem(errorWrapper, errors)
-        val jsonRequest = JsonObjectRequest(
+        val jsonRequest = AdAdaptedJsonObjectRequest(
+            httpQueueManager.getAppId(),
             Request.Method.POST,
             errorUrl,
             json,

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/ext/http/HttpInterceptAdapter.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/ext/http/HttpInterceptAdapter.kt
@@ -4,6 +4,7 @@ import com.adadapted.android.sdk.config.EventStrings
 import com.adadapted.android.sdk.core.intercept.InterceptAdapter
 import com.adadapted.android.sdk.core.intercept.InterceptEvent
 import com.adadapted.android.sdk.core.session.Session
+import com.adadapted.android.sdk.ext.json.AdAdaptedJsonObjectRequest
 import com.adadapted.android.sdk.ext.json.JsonInterceptBuilder
 import com.adadapted.android.sdk.ext.json.JsonInterceptEventBuilder
 import com.android.volley.Request
@@ -19,7 +20,8 @@ class HttpInterceptAdapter(private val initUrl: String, private val eventUrl: St
             return
         }
         val url = initUrl + String.format("?aid=%s", session.getDeviceInfo().appId) + String.format("&uid=%s", session.getDeviceInfo().udid) + String.format("&sid=%s", session.id) + String.format("&sdk=%s", session.getDeviceInfo().sdkVersion)
-        val jsonRequest = JsonObjectRequest(
+        val jsonRequest = AdAdaptedJsonObjectRequest(
+            httpQueueManager.getAppId(),
             Request.Method.GET,
             url,
             null,
@@ -39,7 +41,8 @@ class HttpInterceptAdapter(private val initUrl: String, private val eventUrl: St
 
     override fun sendEvents(session: Session, events: MutableSet<InterceptEvent>) {
         val json = eventBuilder.marshalEvents(session, events)
-        val jsonRequest = JsonObjectRequest(
+        val jsonRequest = AdAdaptedJsonObjectRequest(
+            httpQueueManager.getAppId(),
             Request.Method.POST,
             eventUrl,
             json,

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/ext/http/HttpPayloadAdapter.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/ext/http/HttpPayloadAdapter.kt
@@ -5,6 +5,7 @@ import com.adadapted.android.sdk.core.addit.PayloadAdapter
 import com.adadapted.android.sdk.core.addit.PayloadContentParser
 import com.adadapted.android.sdk.core.addit.PayloadEvent
 import com.adadapted.android.sdk.core.device.DeviceInfo
+import com.adadapted.android.sdk.ext.json.AdAdaptedJsonObjectRequest
 import com.adadapted.android.sdk.ext.json.JsonPayloadBuilder
 import com.android.volley.Request
 import com.android.volley.toolbox.JsonObjectRequest
@@ -16,7 +17,8 @@ class HttpPayloadAdapter(private val pickupUrl: String, private val trackUrl: St
 
     override fun pickup(deviceInfo: DeviceInfo, callback: PayloadAdapter.Callback) {
         val json = builder.buildRequest(deviceInfo)
-        val request = JsonObjectRequest(
+        val request = AdAdaptedJsonObjectRequest(
+            httpQueueManager.getAppId(),
             Request.Method.POST,
             pickupUrl,
             json,
@@ -37,7 +39,8 @@ class HttpPayloadAdapter(private val pickupUrl: String, private val trackUrl: St
 
     override fun publishEvent(event: PayloadEvent) {
         val json = builder.buildEvent(event)
-        val request = JsonObjectRequest(
+        val request = AdAdaptedJsonObjectRequest(
+            httpQueueManager.getAppId(),
             Request.Method.POST,
             trackUrl,
             json,

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/ext/http/HttpQueueManager.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/ext/http/HttpQueueManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.android.volley.Request
 
 interface HttpQueueManager {
-    fun createQueue(context: Context)
+    fun createQueue(context: Context, apiKey: String)
     fun queueRequest(request: Request<*>)
+    fun getAppId(): String
 }

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/ext/http/HttpRequestManager.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/ext/http/HttpRequestManager.kt
@@ -9,9 +9,15 @@ import com.android.volley.toolbox.Volley
 object HttpRequestManager : HttpQueueManager {
     private val LOGTAG = HttpRequestManager::class.java.name
     private lateinit var requestQueue: RequestQueue
+    private lateinit var appId: String
 
-    override fun createQueue(context: Context) {
+    override fun createQueue(context: Context, apiKey: String) {
         requestQueue = Volley.newRequestQueue(context.applicationContext)
+        appId = apiKey
+    }
+
+    override fun getAppId(): String {
+        return appId
     }
 
     @Synchronized

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/ext/http/HttpSessionAdapter.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/ext/http/HttpSessionAdapter.kt
@@ -6,10 +6,12 @@ import com.adadapted.android.sdk.core.session.Session
 import com.adadapted.android.sdk.core.session.SessionAdapter
 import com.adadapted.android.sdk.core.session.SessionAdapter.AdGetListener
 import com.adadapted.android.sdk.core.session.SessionAdapter.SessionInitListener
+import com.adadapted.android.sdk.ext.json.AdAdaptedJsonObjectRequest
 import com.adadapted.android.sdk.ext.json.JsonSessionBuilder
 import com.adadapted.android.sdk.ext.json.JsonSessionRequestBuilder
 import com.android.volley.Request
 import com.android.volley.toolbox.JsonObjectRequest
+
 
 class HttpSessionAdapter(private val initUrl: String, private val refreshUrl: String, private var sessionBuilder: JsonSessionBuilder? = null, private val httpQueueManager: HttpQueueManager = HttpRequestManager) : SessionAdapter {
     private val LOGTAG = HttpSessionAdapter::class.java.name
@@ -18,7 +20,8 @@ class HttpSessionAdapter(private val initUrl: String, private val refreshUrl: St
         val requestBuilder = JsonSessionRequestBuilder()
         sessionBuilder = JsonSessionBuilder(deviceInfo)
         val json = requestBuilder.buildSessionInitRequest(deviceInfo)
-        val jsonRequest = JsonObjectRequest(
+        val jsonRequest = AdAdaptedJsonObjectRequest(
+            httpQueueManager.getAppId(),
             Request.Method.POST,
             initUrl,
             json,
@@ -42,7 +45,8 @@ class HttpSessionAdapter(private val initUrl: String, private val refreshUrl: St
             return
         }
         val url = refreshUrl + String.format("?aid=%s", session.getDeviceInfo().appId) + String.format("&uid=%s", session.getDeviceInfo().udid) + String.format("&sid=%s", session.id) + String.format("&sdk=%s", session.getDeviceInfo().sdkVersion)
-        val request = JsonObjectRequest(
+        val request = AdAdaptedJsonObjectRequest(
+            httpQueueManager.getAppId(),
             Request.Method.GET,
             url,
             null,

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/ext/json/AdAdaptedJsonObjectRequest.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/ext/json/AdAdaptedJsonObjectRequest.kt
@@ -1,0 +1,21 @@
+package com.adadapted.android.sdk.ext.json
+
+import com.android.volley.Response
+import com.android.volley.toolbox.JsonObjectRequest
+import org.json.JSONObject
+
+class AdAdaptedJsonObjectRequest(
+    private var appId: String?,
+    method: Int,
+    url: String,
+    jsonRequest: JSONObject?,
+    listener: Response.Listener<JSONObject>,
+    errorListener: Response.ErrorListener,
+) : JsonObjectRequest(method, url, jsonRequest, listener, errorListener) {
+
+    override fun getHeaders(): MutableMap<String, String> {
+        val params: MutableMap<String, String> = HashMap()
+        params["X-API-KEY"] = appId ?: ""
+        return params
+    }
+}

--- a/app/src/main/java/com/adadapted/sdktestapp/TestAppApplication.java
+++ b/app/src/main/java/com/adadapted/sdktestapp/TestAppApplication.java
@@ -35,8 +35,10 @@ public class TestAppApplication extends Application {
         //AdAdapted.INSTANCE.disableAdTracking(this); //Disable ad tracking completely
 
         AdAdapted.INSTANCE
-                .withAppId("") // #YOUR API KEY GOES HERE#
+                .withAppId("7D58810X6333241C") // #YOUR API KEY GOES HERE#
                 .inEnv(AdAdapted.Env.DEV)
+                .enableKeywordIntercept(true)
+                .enablePayloads(true)
                 //.setCustomIdentifier("customTestId")
                 .setSdkSessionListener(new AaSdkSessionListener() {
                     @Override

--- a/app/src/main/java/com/adadapted/sdktestapp/TestAppApplication.java
+++ b/app/src/main/java/com/adadapted/sdktestapp/TestAppApplication.java
@@ -35,7 +35,7 @@ public class TestAppApplication extends Application {
         //AdAdapted.INSTANCE.disableAdTracking(this); //Disable ad tracking completely
 
         AdAdapted.INSTANCE
-                .withAppId("7D58810X6333241C") // #YOUR API KEY GOES HERE#
+                .withAppId("") // #YOUR API KEY GOES HERE#
                 .inEnv(AdAdapted.Env.DEV)
                 .enableKeywordIntercept(true)
                 .enablePayloads(true)


### PR DESCRIPTION
Update for 3.1.0 version that includes new header information on all requests, new payload flag, and updated stale ad refresh logic.