### PR TITLE
fix: AdZone tap drag accuracy and dependency updates for 4.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add it in your root build.gradle at the **end** of repositories:
 Step 2. Add the dependency (based on latest release version)
 
 	dependencies {
-	        implementation 'com.github.adadaptedinc:android-sdk:4.0.4'
+	        implementation 'com.github.adadaptedinc:android-sdk:4.0.5'
 	}
 
 ## Running the tests

--- a/advertising_sdk/build.gradle
+++ b/advertising_sdk/build.gradle
@@ -23,7 +23,7 @@ android {
         minSdkVersion 23
         //noinspection EditedTargetSdkVersion
         targetSdkVersion 34
-        versionName "3.4.5"
+        versionName "4.0.5"
         buildConfigField("String","VERSION_NAME", "\"${defaultConfig.versionName}\"")
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'aasdk-proguard-rules.pro'
@@ -62,12 +62,12 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-datetime:0.4.0'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1'
-    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'com.google.android.material:material:1.12.0'
     implementation 'io.ktor:ktor-client-android:2.2.4'
-    implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
-    implementation 'androidx.compose.ui:ui:1.5.2'
-    implementation 'androidx.compose.foundation:foundation:1.5.2'
-    implementation 'androidx.compose.material:material:1.5.2'
+    implementation 'com.google.android.gms:play-services-ads-identifier:18.1.0'
+    implementation 'androidx.compose.ui:ui:1.6.7'
+    implementation 'androidx.compose.foundation:foundation:1.6.7'
+    implementation 'androidx.compose.material:material:1.6.7'
 
     testImplementation 'junit:junit:4.13.2'
     //testImplementation 'io.ktor:ktor-client-mock2.2.4'
@@ -96,7 +96,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'com.adadapted'
                 artifactId = 'android-sdk'
-                version = '4.0.4'
+                version = '4.0.5'
             }
         }
     }

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/constants/Config.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/constants/Config.kt
@@ -3,7 +3,7 @@ package com.adadapted.android.sdk.constants
 object Config {
     private var isProd = false
 
-    const val LIBRARY_VERSION: String = "4.0.4"
+    const val LIBRARY_VERSION: String = "4.0.5"
     const val LOG_TAG = "ADADAPTED_ANDROID_SDK"
 
     const val DEFAULT_AD_POLLING = 300000L // If the new Ad polling isn't set it will default to every 5 minutes

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/view/AdWebView.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/view/AdWebView.kt
@@ -82,7 +82,7 @@ internal class AdWebView(context: Context, private val listener: Listener) :
                         return true
                     }
                     MotionEvent.ACTION_UP -> {
-                        // Only notify ad clicked if no significant move event was detected
+                        //Only accept the click if no significant move event was detected
                         if (!isMoved && currentAd.id.isNotEmpty()) {
                             notifyAdClicked()
                         }

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/view/AdWebView.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/view/AdWebView.kt
@@ -5,15 +5,15 @@ import android.content.Context
 import android.graphics.Color
 import android.view.MotionEvent
 import android.view.View
-import android.view.View.OnTouchListener
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import com.adadapted.android.sdk.core.ad.Ad
+import kotlin.math.abs
 
 @SuppressLint("ClickableViewAccessibility", "SetJavaScriptEnabled", "ViewConstructor")
-internal class AdWebView constructor(context: Context, private val listener: Listener) :
+internal class AdWebView(context: Context, private val listener: Listener) :
     WebView(context.applicationContext) {
     internal interface Listener {
         fun onAdLoadedInWebView(ad: Ad)
@@ -59,17 +59,38 @@ internal class AdWebView constructor(context: Context, private val listener: Lis
         setLayerType(View.LAYER_TYPE_SOFTWARE, null)
         setBackgroundColor(Color.TRANSPARENT)
 
-        setOnTouchListener(OnTouchListener { _, event ->
-            when (event.action) {
-                MotionEvent.ACTION_MOVE -> return@OnTouchListener true
-                MotionEvent.ACTION_UP -> {
-                    if (currentAd.id.isNotEmpty()) {
-                        notifyAdClicked()
+        setOnTouchListener(object : OnTouchListener {
+            var isMoved = false
+            private var startX = 0f
+            private var startY = 0f
+            private val moveThreshold = 20f
+
+            override fun onTouch(v: View?, event: MotionEvent?): Boolean {
+                when (event?.action) {
+                    MotionEvent.ACTION_DOWN -> {
+                        isMoved = false
+                        startX = event.x
+                        startY = event.y
+                        return true
                     }
-                    return@OnTouchListener true
+                    MotionEvent.ACTION_MOVE -> {
+                        val deltaX = abs(event.x - startX)
+                        val deltaY = abs(event.y - startY)
+                        if (deltaX > moveThreshold || deltaY > moveThreshold) {
+                            isMoved = true
+                        }
+                        return true
+                    }
+                    MotionEvent.ACTION_UP -> {
+                        // Only notify ad clicked if no significant move event was detected
+                        if (!isMoved && currentAd.id.isNotEmpty()) {
+                            notifyAdClicked()
+                        }
+                        return true
+                    }
                 }
+                return false
             }
-            false
         })
         webViewClient = object : WebViewClient() {
             override fun shouldOverrideUrlLoading(


### PR DESCRIPTION
- AdZoneView no longer registers a touch event when the zone is touched, dragged, and released (i.e. an accidental touch on a scroll or swipe)
- Multiple compose and material dependencies have been updated