### PR TITLE
feat: adding noncontent ad notification hooks and bumping to 4.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add it in your root build.gradle at the **end** of repositories:
 Step 2. Add the dependency (based on latest release version)
 
 	dependencies {
-	        implementation 'com.github.adadaptedinc:android-sdk:4.0.5'
+	        implementation 'com.github.adadaptedinc:android-sdk:4.0.6'
 	}
 
 ## Running the tests

--- a/advertising_sdk/build.gradle
+++ b/advertising_sdk/build.gradle
@@ -23,7 +23,7 @@ android {
         minSdkVersion 23
         //noinspection EditedTargetSdkVersion
         targetSdkVersion 34
-        versionName "4.0.5"
+        versionName "4.0.6"
         buildConfigField("String","VERSION_NAME", "\"${defaultConfig.versionName}\"")
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'aasdk-proguard-rules.pro'
@@ -96,7 +96,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'com.adadapted'
                 artifactId = 'android-sdk'
-                version = '4.0.5'
+                version = '4.0.6'
             }
         }
     }

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/constants/Config.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/constants/Config.kt
@@ -3,7 +3,7 @@ package com.adadapted.android.sdk.constants
 object Config {
     private var isProd = false
 
-    const val LIBRARY_VERSION: String = "4.0.5"
+    const val LIBRARY_VERSION: String = "4.0.6"
     const val LOG_TAG = "ADADAPTED_ANDROID_SDK"
 
     const val DEFAULT_AD_POLLING = 300000L // If the new Ad polling isn't set it will default to every 5 minutes

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/ad/AdContentListener.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/ad/AdContentListener.kt
@@ -4,4 +4,7 @@ import com.adadapted.android.sdk.core.atl.AddToListContent
 
 interface AdContentListener {
     fun onContentAvailable(zoneId: String, content: AddToListContent)
+    fun onNonContentAction(zoneId: String, adId: String) {
+        // Default implementation to make this optional
+    }
 }

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/ad/AdContentPublisher.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/ad/AdContentPublisher.kt
@@ -20,8 +20,16 @@ object AdContentPublisher {
             return
         }
         transporter.dispatchToMain {
-        for (listener in listeners) {
+            for (listener in listeners) {
                 listener.onContentAvailable(zoneId, content)
+            }
+        }
+    }
+
+    fun publishNonContentNotification(zoneId: String, adId: String) {
+        transporter.dispatchToMain {
+            for (listener in listeners) {
+                listener.onNonContentAction(zoneId, adId)
             }
         }
     }

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/view/AdZonePresenter.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/view/AdZonePresenter.kt
@@ -211,10 +211,12 @@ class AdZonePresenter(private val adViewHandler: AdViewHandler, private val sess
 
     private fun handleLinkAction(ad: Ad) {
         adViewHandler.handleLink(ad)
+        AdContentPublisher.publishNonContentNotification(zoneId, ad.id)
     }
 
     private fun handlePopupAction(ad: Ad) {
         adViewHandler.handlePopup(ad)
+        AdContentPublisher.publishNonContentNotification(zoneId, ad.id)
     }
 
     private fun notifyZoneAvailable() {

--- a/advertising_sdk/src/test/java/com/adadapted/android/sdk/core/ad/AdContentPublisherTest.kt
+++ b/advertising_sdk/src/test/java/com/adadapted/android/sdk/core/ad/AdContentPublisherTest.kt
@@ -69,14 +69,29 @@ class AdContentPublisherTest {
         assertEquals("", testListener.resultZoneId)
         assertNull(testListener.resultContent)
     }
+
+    @Test
+    fun listenerIsAddedAndNonContentPublished() {
+        val testListener = TestAdContentListener()
+        AdContentPublisher.addListener(testListener)
+        AdContentPublisher.publishNonContentNotification("testZoneId", "testAdId")
+        assertEquals("testZoneId", testListener.resultZoneId)
+        assertEquals("testAdId", testListener.resultAdId)
+    }
 }
 
 class TestAdContentListener: AdContentListener {
     var resultZoneId = ""
+    var resultAdId = ""
     var resultContent: AddToListContent? = null
 
     override fun onContentAvailable(zoneId: String, content: AddToListContent) {
         resultZoneId = zoneId
         resultContent = content
+    }
+
+    override fun onNonContentAction(zoneId: String, adId: String) {
+        resultZoneId = zoneId
+        resultAdId = adId
     }
 }

--- a/app/src/main/java/com/adadapted/sdktestapp/ui/todo/fragment/TodoListDetailFragment.java
+++ b/app/src/main/java/com/adadapted/sdktestapp/ui/todo/fragment/TodoListDetailFragment.java
@@ -241,6 +241,12 @@ public class TodoListDetailFragment extends ListFragment implements AaZoneView.L
         content.acknowledge();
     }
 
+    @Override
+    public void onNonContentAction(String zoneId, String adId) {
+        String checkZone = zoneId;
+        String checkAd = adId;
+    }
+
     /**
      * This interface must be implemented by activities that contain this
      * fragment to allow an interaction in this fragment to be communicated


### PR DESCRIPTION
- Adding the ability to listen for ad interactions on non-content delivering ads.