### PR TITLE
fix: using java.util.date instead of kotlinx for epoch timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add it in your root build.gradle at the **end** of repositories:
 Step 2. Add the dependency (based on latest release version)
 
 	dependencies {
-	        implementation 'com.github.adadaptedinc:android-sdk:4.0.6'
+	        implementation 'com.github.adadaptedinc:android-sdk:4.0.7'
 	}
 
 ## Running the tests

--- a/advertising_sdk/build.gradle
+++ b/advertising_sdk/build.gradle
@@ -23,7 +23,7 @@ android {
         minSdkVersion 23
         //noinspection EditedTargetSdkVersion
         targetSdkVersion 34
-        versionName "4.0.6"
+        versionName "4.0.7"
         buildConfigField("String","VERSION_NAME", "\"${defaultConfig.versionName}\"")
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'aasdk-proguard-rules.pro'
@@ -96,7 +96,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'com.adadapted'
                 artifactId = 'android-sdk'
-                version = '4.0.6'
+                version = '4.0.7'
             }
         }
     }

--- a/advertising_sdk/build.gradle
+++ b/advertising_sdk/build.gradle
@@ -59,7 +59,6 @@ dependencies {
     implementation("io.ktor:ktor-client-core:2.2.4")
     implementation("io.ktor:ktor-serialization-kotlinx-json:2.2.4")
     implementation("io.ktor:ktor-client-content-negotiation:2.2.4")
-    implementation 'org.jetbrains.kotlinx:kotlinx-datetime:0.4.0'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1'
     implementation 'com.google.android.material:material:1.12.0'

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/constants/Config.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/constants/Config.kt
@@ -3,7 +3,7 @@ package com.adadapted.android.sdk.constants
 object Config {
     private var isProd = false
 
-    const val LIBRARY_VERSION: String = "4.0.6"
+    const val LIBRARY_VERSION: String = "4.0.7"
     const val LOG_TAG = "ADADAPTED_ANDROID_SDK"
 
     const val DEFAULT_AD_POLLING = 300000L // If the new Ad polling isn't set it will default to every 5 minutes

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/device/DeviceInfoExtractor.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/device/DeviceInfoExtractor.kt
@@ -12,8 +12,8 @@ import com.adadapted.android.sdk.core.view.DimensionConverter
 import com.google.android.gms.ads.identifier.AdvertisingIdClient
 import com.google.android.gms.common.GooglePlayServicesNotAvailableException
 import com.google.android.gms.common.GooglePlayServicesRepairableException
-import kotlinx.datetime.Clock
 import java.io.IOException
+import java.util.Date
 import java.util.TimeZone
 import java.util.Locale
 
@@ -93,7 +93,7 @@ open class DeviceInfoExtractor(context: Context) {
             dw = mWidth,
             density = mDensity.toString(),
             sdkVersion = Config.LIBRARY_VERSION,
-            createdAt = Clock.System.now().epochSeconds
+            createdAt = Date().time / 1000
         )
     }
 

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/event/AdEvent.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/event/AdEvent.kt
@@ -1,8 +1,8 @@
 package com.adadapted.android.sdk.core.event
 
-import kotlinx.datetime.Clock
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.util.Date
 
 @Serializable
 data class AdEvent(
@@ -14,5 +14,5 @@ data class AdEvent(
     @SerialName("event_type")
     val eventType: String,
     @SerialName("created_at")
-    val createdAt: Long = Clock.System.now().epochSeconds
+    val createdAt: Long = Date().time / 1000
 )

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/event/SdkError.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/event/SdkError.kt
@@ -1,8 +1,8 @@
 package com.adadapted.android.sdk.core.event
 
-import kotlinx.datetime.Clock
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.util.Date
 
 @Serializable
 data class SdkError(
@@ -13,5 +13,5 @@ data class SdkError(
     @SerialName("error_params")
     val params: Map<String, String>,
     @SerialName("error_timestamp")
-    val timeStamp: Long = Clock.System.now().epochSeconds
+    val timeStamp: Long = Date().time / 1000
 )

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/event/SdkEvent.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/event/SdkEvent.kt
@@ -1,8 +1,8 @@
 package com.adadapted.android.sdk.core.event
 
-import kotlinx.datetime.Clock
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.util.Date
 
 @Serializable
 data class SdkEvent(
@@ -11,7 +11,7 @@ data class SdkEvent(
     @SerialName("event_name")
     val name: String,
     @SerialName("event_timestamp")
-    val timeStamp: Long = Clock.System.now().epochSeconds,
+    val timeStamp: Long = Date().time / 1000,
     @SerialName("event_params")
     val params: Map<String, String>
 )

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/keyword/InterceptEvent.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/keyword/InterceptEvent.kt
@@ -1,8 +1,8 @@
 package com.adadapted.android.sdk.core.keyword
 
-import kotlinx.datetime.Clock
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.util.Date
 
 @Serializable
 data class InterceptEvent(
@@ -16,7 +16,7 @@ data class InterceptEvent(
     val termId: String = "",
     val term: String = "",
     @SerialName("created_at")
-    val createdAt: Long = Clock.System.now().epochSeconds
+    val createdAt: Long = Date().time / 1000
 ) {
 
     fun supersedes(e: InterceptEvent): Boolean {

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/payload/PayloadEvent.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/payload/PayloadEvent.kt
@@ -1,7 +1,7 @@
 package com.adadapted.android.sdk.core.payload
 
-import kotlinx.datetime.Clock
+import java.util.Date
 
 class PayloadEvent internal constructor(val payloadId: String, val status: String) {
-    val timestamp: Long = Clock.System.now().epochSeconds
+    val timestamp: Long = Date().time / 1000
 }

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/payload/PayloadRequestBuilder.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/payload/PayloadRequestBuilder.kt
@@ -1,10 +1,10 @@
 package com.adadapted.android.sdk.core.payload
 
 import com.adadapted.android.sdk.core.device.DeviceInfo
-import kotlinx.datetime.Clock
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import java.util.Date
 
 object PayloadRequestBuilder {
     fun buildRequest(deviceInfo: DeviceInfo): PayloadRequest {
@@ -18,7 +18,7 @@ object PayloadRequestBuilder {
                 os,
                 osv,
                 sdkVersion,
-                Clock.System.now().epochSeconds
+                Date().time / 1000
             )
         }
     }

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/session/Session.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/session/Session.kt
@@ -3,9 +3,9 @@ package com.adadapted.android.sdk.core.session
 import com.adadapted.android.sdk.constants.Config
 import com.adadapted.android.sdk.core.device.DeviceInfo
 import com.adadapted.android.sdk.core.view.Zone
-import kotlinx.datetime.Clock
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.util.Date
 
 @Serializable
 data class Session(
@@ -29,7 +29,7 @@ data class Session(
     }
 
     fun hasExpired(): Boolean {
-        return Clock.System.now().epochSeconds > expiration
+        return Date().time / 1000 > expiration
     }
 
     fun getZone(zoneId: String): Zone {

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/view/AdZonePresenter.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/view/AdZonePresenter.kt
@@ -10,7 +10,7 @@ import com.adadapted.android.sdk.core.log.AALogger
 import com.adadapted.android.sdk.core.session.Session
 import com.adadapted.android.sdk.core.session.SessionClient
 import com.adadapted.android.sdk.core.session.SessionListener
-import kotlinx.datetime.Clock
+import java.util.Date
 
 interface AdZonePresenterListener {
     fun onZoneAvailable(zone: Zone)
@@ -274,6 +274,6 @@ class AdZonePresenter(private val adViewHandler: AdViewHandler, private val sess
         attached = false
         zoneLoaded = false
         currentZone = Zone()
-        randomAdStartPosition = (Clock.System.now().epochSeconds.toInt() % 10)
+        randomAdStartPosition = ((Date().time / 1000).toInt() % 10)
     }
 }

--- a/advertising_sdk/src/test/java/com/adadapted/android/sdk/core/session/SessionTest.kt
+++ b/advertising_sdk/src/test/java/com/adadapted/android/sdk/core/session/SessionTest.kt
@@ -7,7 +7,7 @@ import com.adadapted.android.sdk.core.view.Zone
 import junit.framework.Assert.assertFalse
 import org.junit.Assert
 import org.junit.Test
-import java.time.Instant
+import java.util.Date
 
 class SessionTest {
     @Test
@@ -74,6 +74,6 @@ class SessionTest {
     }
 
     fun buildTestSession(): Session {
-        return Session("testId", willServeAds = true, hasAds = true, refreshTime = 1L, expiration = Instant.now().epochSecond - 1)
+        return Session("testId", willServeAds = true, hasAds = true, refreshTime = 1L, expiration = Date().time / 1000 - 1)
     }
 }


### PR DESCRIPTION
- kotlinx.datetime.Clock leverages a java feature that is only available in java version 8 or higher, reverting to use java.util.date instead to ensure backwards compatibility with older java versions.