### PR TITLE
fix: reverting swap of item and list for listmanager events

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add it in your root build.gradle at the **end** of repositories:
 Step 2. Add the dependency (based on latest release version)
 
 	dependencies {
-	        implementation 'com.github.adadaptedinc:android-sdk:4.0.12'
+	        implementation 'com.github.adadaptedinc:android-sdk:4.0.13'
 	}
 
 ## Running the tests

--- a/advertising_sdk/build.gradle
+++ b/advertising_sdk/build.gradle
@@ -23,7 +23,7 @@ android {
         minSdkVersion 23
         //noinspection EditedTargetSdkVersion
         targetSdkVersion 34
-        versionName "4.0.12"
+        versionName "4.0.13"
         buildConfigField("String","VERSION_NAME", "\"${defaultConfig.versionName}\"")
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'aasdk-proguard-rules.pro'
@@ -95,7 +95,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'com.adadapted'
                 artifactId = 'android-sdk'
-                version = '4.0.12'
+                version = '4.0.13'
             }
         }
     }

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/AdAdaptedListManager.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/AdAdaptedListManager.kt
@@ -10,7 +10,7 @@ object AdAdaptedListManager {
     private const val ITEM_NAME = "item_name"
 
     @Synchronized
-    fun itemAddedToList(item: String, list: String = "") {
+    fun itemAddedToList(list: String = "", item: String,) {
         if (item.isEmpty()) {
             return
         }
@@ -19,7 +19,7 @@ object AdAdaptedListManager {
     }
 
     @Synchronized
-    fun itemCrossedOffList(item: String, list: String = "") {
+    fun itemCrossedOffList(list: String = "", item: String) {
         if (item.isEmpty()) {
             return
         }
@@ -28,7 +28,7 @@ object AdAdaptedListManager {
     }
 
     @Synchronized
-    fun itemDeletedFromList(item: String, list: String = "") {
+    fun itemDeletedFromList(list: String = "", item: String) {
         if (item.isEmpty()) {
             return
         }

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/constants/Config.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/constants/Config.kt
@@ -3,7 +3,7 @@ package com.adadapted.android.sdk.constants
 object Config {
     private var isProd = false
 
-    const val LIBRARY_VERSION: String = "4.0.12"
+    const val LIBRARY_VERSION: String = "4.0.13"
     const val LOG_TAG = "ADADAPTED_ANDROID_SDK"
 
     const val DEFAULT_AD_POLLING = 300000L // If the new Ad polling isn't set it will default to every 5 minutes

--- a/advertising_sdk/src/test/java/com/adadapted/android/sdk/core/addit/AdAdaptedListManagerTest.kt
+++ b/advertising_sdk/src/test/java/com/adadapted/android/sdk/core/addit/AdAdaptedListManagerTest.kt
@@ -42,7 +42,7 @@ class AdAdaptedListManagerTest {
 
     @Test
     fun itemAddedToListTest() {
-        AdAdaptedListManager.itemAddedToList("TestItem")
+        AdAdaptedListManager.itemAddedToList(item = "TestItem")
         EventClient.onPublishEvents()
         assertEquals(EventStrings.USER_ADDED_TO_LIST, TestEventAdapter.testSdkEvents.first().name)
         assertEquals("TestItem", TestEventAdapter.testSdkEvents.first().params.getValue("item_name"))
@@ -59,7 +59,7 @@ class AdAdaptedListManagerTest {
 
     @Test
     fun itemCrossedOffListTest() {
-        AdAdaptedListManager.itemCrossedOffList("TestItem")
+        AdAdaptedListManager.itemCrossedOffList(item = "TestItem")
         EventClient.onPublishEvents()
         assertEquals(EventStrings.USER_CROSSED_OFF_LIST, TestEventAdapter.testSdkEvents.first().name)
         assertEquals("TestItem", TestEventAdapter.testSdkEvents.first().params.getValue("item_name"))
@@ -76,7 +76,7 @@ class AdAdaptedListManagerTest {
 
     @Test
     fun itemDeletedFromListTest() {
-        AdAdaptedListManager.itemDeletedFromList("TestItem")
+        AdAdaptedListManager.itemDeletedFromList(item = "TestItem")
         EventClient.onPublishEvents()
         assertEquals(EventStrings.USER_DELETED_FROM_LIST, TestEventAdapter.testSdkEvents.first().name)
         assertEquals("TestItem", TestEventAdapter.testSdkEvents.first().params.getValue("item_name"))


### PR DESCRIPTION
- Reverting the order of the list manager event to take the list first followed by the item.
- Bump to 4.0.13