### PR TITLE
feat: updating ad rotation logic to prevent skips on external ads for 4.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add it in your root build.gradle at the **end** of repositories:
 Step 2. Add the dependency (based on latest release version)
 
 	dependencies {
-	        implementation 'com.github.adadaptedinc:android-sdk:4.1.1'
+	        implementation 'com.github.adadaptedinc:android-sdk:4.1.2'
 	}
 
 ## Running the tests

--- a/advertising_sdk/build.gradle
+++ b/advertising_sdk/build.gradle
@@ -23,7 +23,7 @@ android {
         minSdkVersion 23
         //noinspection EditedTargetSdkVersion
         targetSdkVersion 34
-        versionName "4.1.1"
+        versionName "4.1.2"
         buildConfigField("String","VERSION_NAME", "\"${defaultConfig.versionName}\"")
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'aasdk-proguard-rules.pro'
@@ -96,7 +96,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'com.adadapted'
                 artifactId = 'android-sdk'
-                version = '4.1.1'
+                version = '4.1.2'
             }
         }
     }

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/constants/Config.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/constants/Config.kt
@@ -3,7 +3,7 @@ package com.adadapted.android.sdk.constants
 object Config {
     private var isProd = false
 
-    const val LIBRARY_VERSION: String = "4.1.1"
+    const val LIBRARY_VERSION: String = "4.1.2"
     const val LOG_TAG = "ADADAPTED_ANDROID_SDK"
 
     const val DEFAULT_AD_POLLING = 300000L // If the new Ad polling isn't set it will default to every 5 minutes

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/view/AdZonePresenter.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/view/AdZonePresenter.kt
@@ -79,15 +79,17 @@ class AdZonePresenter(private val adViewHandler: AdViewHandler, private val sess
         sessionClient?.clearZoneContext()
     }
 
-    private fun setNextAd() {
+    private fun setNextAd(isFreshLoad: Boolean = false) {
         if (!zoneLoaded || sessionClient?.hasStaleAds() == true) {
             return
         }
         completeCurrentAd()
 
         currentAd = if (adZonePresenterListener != null && currentZone.hasAds()) {
+            if (!isFreshLoad) {
+                randomAdStartPosition++
+            }
             val adPosition = randomAdStartPosition % currentZone.ads.size
-            randomAdStartPosition++
             currentZone.ads[adPosition]
         } else {
             Ad()
@@ -262,7 +264,7 @@ class AdZonePresenter(private val adViewHandler: AdViewHandler, private val sess
         zoneLoaded = true
         currentZone = zone
         restartTimer()
-        setNextAd()
+        setNextAd(isFreshLoad = true)
     }
 
     override fun onSessionAvailable(session: Session) {

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/view/AdZonePresenter.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/view/AdZonePresenter.kt
@@ -260,11 +260,11 @@ class AdZonePresenter(private val adViewHandler: AdViewHandler, private val sess
         return false
     }
 
-    private fun updateCurrentZone(zone: Zone) {
+    private fun updateCurrentZone(zone: Zone, isFromRefresh: Boolean = false) {
         zoneLoaded = true
         currentZone = zone
         restartTimer()
-        setNextAd(isFreshLoad = true)
+        setNextAd(isFreshLoad = !isFromRefresh)
     }
 
     override fun onSessionAvailable(session: Session) {
@@ -278,7 +278,7 @@ class AdZonePresenter(private val adViewHandler: AdViewHandler, private val sess
     }
 
     override fun onAdsAvailable(session: Session) {
-        updateCurrentZone(session.getZone(zoneId))
+        updateCurrentZone(session.getZone(zoneId), isFromRefresh = true)
         notifyAdsRefreshed()
     }
 

--- a/app/src/main/java/com/adadapted/sdktestapp/TestAppApplication.java
+++ b/app/src/main/java/com/adadapted/sdktestapp/TestAppApplication.java
@@ -40,6 +40,7 @@ public class TestAppApplication extends Application {
                 .enableKeywordIntercept(true)
                 .enablePayloads(true)
                 //.setCustomIdentifier("customTestId")
+                .enableDebugLogging()
                 .setSdkSessionListener(new AaSdkSessionListener() {
                     @Override
                     public void onHasAdsToServe(boolean hasAds, @NonNull List<String> availableZoneIds) {


### PR DESCRIPTION
- Updating ad rotation logic to only increment when not being freshly started/created to prevent excess ad rotations.