### PR TITLE
feat: updating dimension converter for fixed aspect ads and bump to 4.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add it in your root build.gradle at the **end** of repositories:
 Step 2. Add the dependency (based on latest release version)
 
 	dependencies {
-	        implementation 'com.github.adadaptedinc:android-sdk:4.1.2'
+	        implementation 'com.github.adadaptedinc:android-sdk:4.1.3'
 	}
 
 ## Running the tests

--- a/advertising_sdk/build.gradle
+++ b/advertising_sdk/build.gradle
@@ -23,7 +23,7 @@ android {
         minSdkVersion 23
         //noinspection EditedTargetSdkVersion
         targetSdkVersion 34
-        versionName "4.1.2"
+        versionName "4.1.3"
         buildConfigField("String","VERSION_NAME", "\"${defaultConfig.versionName}\"")
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'aasdk-proguard-rules.pro'
@@ -96,7 +96,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'com.adadapted'
                 artifactId = 'android-sdk'
-                version = '4.1.2'
+                version = '4.1.3'
             }
         }
     }

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/constants/Config.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/constants/Config.kt
@@ -3,7 +3,7 @@ package com.adadapted.android.sdk.constants
 object Config {
     private var isProd = false
 
-    const val LIBRARY_VERSION: String = "4.1.2"
+    const val LIBRARY_VERSION: String = "4.1.3"
     const val LOG_TAG = "ADADAPTED_ANDROID_SDK"
 
     const val DEFAULT_AD_POLLING = 300000L // If the new Ad polling isn't set it will default to every 5 minutes

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/view/AaZoneView.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/view/AaZoneView.kt
@@ -30,6 +30,7 @@ class AaZoneView : RelativeLayout, AdZonePresenterListener, AdWebView.Listener {
     private var isAdVisible = true
     private var webViewLoaded = false
     private var isAdaptiveSizingEnabled = false
+    private var isFixedAspectRatioEnabled = false
 
 
     constructor(context: Context) : super(context.applicationContext) {
@@ -126,12 +127,8 @@ class AaZoneView : RelativeLayout, AdZonePresenterListener, AdWebView.Listener {
         isAdaptiveSizingEnabled = value
     }
 
-    fun resizeAdZoneView(width: Int, height: Int) {
-        Handler(Looper.getMainLooper()).post {
-            val resizedLayoutParams = LayoutParams(width, height)
-            this.layoutParams = resizedLayoutParams
-            webView.layoutParams = resizedLayoutParams
-        }
+    fun enableFixedAspectRatio(value: Boolean) {
+        isFixedAspectRatioEnabled = value
     }
 
     override fun onZoneAvailable(zone: Zone) {
@@ -143,11 +140,19 @@ class AaZoneView : RelativeLayout, AdZonePresenterListener, AdWebView.Listener {
                     LayoutParams.MATCH_PARENT
                 )
             } else {
-                val dimension = zone.dimensions[Dimension.Orientation.PORT]
-                LayoutParams(
-                    dimension?.width ?: LayoutParams.MATCH_PARENT,
-                    dimension?.height ?: LayoutParams.MATCH_PARENT
-                )
+                if(isFixedAspectRatioEnabled) {
+                    val paDimensions = zone.pixelAccurateDimensions[Dimension.Orientation.PORT]
+                    LayoutParams(
+                        paDimensions?.width ?: LayoutParams.MATCH_PARENT,
+                        paDimensions?.height ?: LayoutParams.MATCH_PARENT
+                    )
+                } else {
+                    val dimensions = zone.dimensions[Dimension.Orientation.PORT]
+                    LayoutParams(
+                        dimensions?.width ?: LayoutParams.MATCH_PARENT,
+                        dimensions?.height ?: LayoutParams.MATCH_PARENT
+                    )
+                }
             }
         }
         Handler(Looper.getMainLooper()).post {

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/view/DimensionConverter.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/view/DimensionConverter.kt
@@ -1,5 +1,8 @@
 package com.adadapted.android.sdk.core.view
 
+import android.content.res.Resources
+import android.util.DisplayMetrics
+
 object DimensionConverter {
     private var scale: Float = 0f
 
@@ -11,5 +14,27 @@ object DimensionConverter {
         return if (dpValue > 0) {
             (dpValue * scale + 0.5f).toInt()
         } else dpValue
+    }
+
+    fun scaleDimensions(originalWidth: Int, originalHeight: Int): Dimension {
+        val displayMetrics: DisplayMetrics = Resources.getSystem().displayMetrics
+        val screenWidthDp = displayMetrics.widthPixels / displayMetrics.density
+        val screenHeightDp = displayMetrics.heightPixels / displayMetrics.density
+
+        // Calculate the aspect ratio of the original dimensions
+        val aspectRatio = originalWidth.toFloat() / originalHeight.toFloat()
+
+        // Scale dimensions proportionally to fit the device
+        val scaledWidth: Int
+        val scaledHeight: Int
+        if (screenWidthDp / aspectRatio <= screenHeightDp) {
+            scaledWidth = (screenWidthDp * displayMetrics.density).toInt()
+            scaledHeight = (scaledWidth / aspectRatio).toInt()
+        } else {
+            scaledHeight = (screenHeightDp * displayMetrics.density).toInt()
+            scaledWidth = (scaledHeight * aspectRatio).toInt()
+        }
+
+        return Dimension(width = scaledWidth, height = scaledHeight)
     }
 }

--- a/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/view/Zone.kt
+++ b/advertising_sdk/src/main/java/com/adadapted/android/sdk/core/view/Zone.kt
@@ -31,11 +31,25 @@ data class Zone(val id: String = "", val ads: List<Ad> = listOf()) {
         return@lazy dimensionsToReturn
     }
 
+    val pixelAccurateDimensions by lazy {
+        val dimensionsToReturn: MutableMap<String, Dimension> = HashMap()
+        val scaledDimenPort = calculatePixelAccurateDimensionValue(portWidth.toInt(), portHeight.toInt())
+        val scaledDimenLand = calculatePixelAccurateDimensionValue(landWidth.toInt(), landHeight.toInt())
+
+        dimensionsToReturn[Dimension.Orientation.PORT] = scaledDimenPort
+        dimensionsToReturn[Dimension.Orientation.LAND] = scaledDimenLand
+        return@lazy dimensionsToReturn
+    }
+
     fun hasAds(): Boolean {
         return ads.isNotEmpty()
     }
 
     private fun calculateDimensionValue(value: Int): Int {
         return DimensionConverter.convertDpToPx(value)
+    }
+
+    private fun calculatePixelAccurateDimensionValue(width: Int, height: Int): Dimension {
+        return DimensionConverter.scaleDimensions(width, height)
     }
 }


### PR DESCRIPTION
- Added new optional method **enableFixedAspectRatio(value: Boolean)** to allow for resizing of ads based on dimensions set to the proper aspect ratio in platform.